### PR TITLE
Add MP3 transcription script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# transcription
+# Transcription Tool
+
+This repository provides a simple command line script for transcribing MP3 files to text using [OpenAI Whisper](https://github.com/openai/whisper).
+
+## Requirements
+
+Install the dependencies with pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+You will also need `ffmpeg` installed on your system.
+
+## Usage
+
+Run the `transcribe.py` script with the path to your audio file. Optionally specify an output text file and the model size (e.g. `tiny`, `base`, `small`, `medium`, `large`).
+
+```bash
+python transcribe.py path/to/file.mp3 output.txt --model base
+```
+
+If no output file is provided, a `.txt` file with the same name as the input will be created.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai-whisper
+torch
+ffmpeg-python
+

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,0 +1,32 @@
+import argparse
+import whisper
+from pathlib import Path
+
+
+def transcribe_audio(input_path: str, output_path: str, model_name: str = "base"):
+    model = whisper.load_model(model_name)
+    result = model.transcribe(input_path)
+    text = result.get("text", "")
+    Path(output_path).write_text(text, encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe MP3 files using OpenAI Whisper")
+    parser.add_argument("input", help="Path to input MP3 file")
+    parser.add_argument("output", nargs="?", help="Path to output text file; defaults to input filename with .txt")
+    parser.add_argument("--model", default="base", help="Whisper model size to use (tiny, base, small, medium, large)")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        output_path = input_path.with_suffix('.txt')
+
+    transcribe_audio(str(input_path), str(output_path), model_name=args.model)
+    print(f"Transcription saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- provide `transcribe.py` for converting mp3 files to text with OpenAI Whisper
- document installation and usage in `README.md`
- list `openai-whisper` and related dependencies in `requirements.txt`

## Testing
- `python -m py_compile transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_684342a5ad6883268f3c11b243d7e371