### PR TITLE
Add folder transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# transcription
+# Transcription Tool
+
+This repository provides a simple command line script for transcribing MP3 files to text using [OpenAI Whisper](https://github.com/openai/whisper).
+
+## Requirements
+
+Install the dependencies with pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+You will also need `ffmpeg` installed on your system.
+
+## Usage
+
+Run the `transcribe.py` script with the path to a folder of MP3 files. Optionally specify an output folder and the model size (e.g. `tiny`, `base`, `small`, `medium`, `large`).
+
+```bash
+python transcribe.py path/to/folder path/to/output --model base
+```
+
+If no output folder is provided, the transcriptions will be written alongside the MP3 files in the input folder. Each MP3 is saved with the same base name and a `.txt` extension.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai-whisper
+torch
+ffmpeg-python
+

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,0 +1,51 @@
+import argparse
+import whisper
+from pathlib import Path
+
+
+def transcribe_audio(input_path: str, output_path: str, model_name: str = "base"):
+    model = whisper.load_model(model_name)
+    result = model.transcribe(input_path)
+    text = result.get("text", "")
+    Path(output_path).write_text(text, encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Transcribe all MP3 files in a folder using OpenAI Whisper"
+    )
+    parser.add_argument("input", help="Path to folder with MP3 files")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="Output folder; defaults to the input folder",
+    )
+    parser.add_argument(
+        "--model",
+        default="base",
+        help="Whisper model size to use (tiny, base, small, medium, large)",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output) if args.output else input_path
+
+    if not input_path.is_dir():
+        parser.error("input path must be a folder")
+
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    mp3_files = sorted(input_path.glob("*.mp3"))
+    if not mp3_files:
+        print("No MP3 files found in the input folder")
+        return
+
+    for mp3_file in mp3_files:
+        out_file = output_path / mp3_file.with_suffix(".txt").name
+        transcribe_audio(str(mp3_file), str(out_file), model_name=args.model)
+        print(f"Transcription saved to {out_file}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- allow specifying a folder of mp3 files instead of a single file
- write transcripts for every mp3 into an output directory
- update README with new usage instructions

## Testing
- `python -m py_compile transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_684342a5ad6883268f3c11b243d7e371