### PR TITLE
Add simple Tkinter GUI for MP3 transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ python transcribe.py path/to/folder path/to/output --model base
 If no output folder is provided, the transcriptions will be written alongside the MP3 files in the input folder. Each MP3 is saved with the same base name and a `.txt` extension.
 
 
+
+## Graphical Interface
+
+A simple Tkinter-based GUI is provided in `transcribe_gui.py`. Run it with:
+
+```bash
+python transcribe_gui.py
+```
+
+Use the **Add Files** button to select one or more MP3 files. Choose the Whisper model size from the dropdown and click **Start** to transcribe the selected files. Each transcription is saved next to its audio file with a `.txt` extension.
+

--- a/transcribe_gui.py
+++ b/transcribe_gui.py
@@ -1,0 +1,62 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+import threading
+
+from transcribe import transcribe_audio
+
+
+class TranscriptionApp:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.root.title("MP3 Transcription Tool")
+        self.files = []
+
+        self.file_listbox = tk.Listbox(root, width=60)
+        self.file_listbox.pack(padx=10, pady=10)
+
+        controls = tk.Frame(root)
+        controls.pack(padx=10, pady=5)
+
+        self.model_var = tk.StringVar(value="base")
+        tk.Label(controls, text="Model:").pack(side=tk.LEFT)
+        tk.OptionMenu(controls, self.model_var, "tiny", "base", "small", "medium", "large").pack(side=tk.LEFT)
+
+        tk.Button(controls, text="Add Files", command=self.add_files).pack(side=tk.LEFT, padx=5)
+        tk.Button(controls, text="Start", command=self.start_transcription).pack(side=tk.LEFT)
+
+        self.status_var = tk.StringVar()
+        tk.Label(root, textvariable=self.status_var).pack(pady=5)
+
+    def add_files(self):
+        filenames = filedialog.askopenfilenames(filetypes=[("MP3 files", "*.mp3")])
+        for name in filenames:
+            if name not in self.files:
+                self.files.append(name)
+                self.file_listbox.insert(tk.END, name)
+
+    def start_transcription(self):
+        if not self.files:
+            messagebox.showwarning("No files", "Please add MP3 files to transcribe.")
+            return
+        threading.Thread(target=self._transcribe_files, daemon=True).start()
+
+    def _transcribe_files(self):
+        self.status_var.set("Starting transcription...")
+        model = self.model_var.get()
+        for path in self.files:
+            mp3_path = Path(path)
+            out_file = mp3_path.with_suffix(".txt")
+            self.status_var.set(f"Transcribing {mp3_path.name}...")
+            transcribe_audio(str(mp3_path), str(out_file), model_name=model)
+        self.status_var.set("Done")
+
+
+def main():
+    root = tk.Tk()
+    app = TranscriptionApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a basic GUI in `transcribe_gui.py` to select multiple mp3 files and run transcription
- document how to use the GUI in the README

## Testing
- `python -m py_compile transcribe_gui.py transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_6844819cd31c8326b6ef4bec975adb55